### PR TITLE
double click on error line.

### DIFF
--- a/Ox.sublime-build
+++ b/Ox.sublime-build
@@ -1,4 +1,5 @@
 {
 	"cmd": ["oxl", "-rp1", "${file}"],
+	"file_regex": "^([^ ]+)[ ]*[(]([^()]+)[)]",
 	"selector": "source.ox"
 }


### PR DESCRIPTION
Allow to jump  to error line by double-click on the error line message (or by pressing F4)

(see "closed issues" for more information)
